### PR TITLE
Update styling on items view

### DIFF
--- a/app/assets/stylesheets/categories_items.scss
+++ b/app/assets/stylesheets/categories_items.scss
@@ -16,6 +16,9 @@
     width: 100%;
   }
   .item-card {
+    margin: 10px auto;
+    padding: 10px;
+    border-radius: 5px;
     .item-card-image {
       text-align: center;
       img {
@@ -24,20 +27,26 @@
     }
     .item-info {
       margin: 10px;
-      aside {
-        display: inline-block;
-        width: 24%;
-      }
+      display: inline-flex;
+      flex-flow: row nowrap;
+      justify-content: space-between;
+      align-items: center;
       .item-title {
-        width: 44%;
+        order: 1;
+        width: 33%;
       }
-      .item-quantity input {
-        width: 44%;
-        float: right;
-        border: 1px solid $black;
+      .item-quantity {
+        order: 3;
+        width: 10%;
+        input {
+          width: 100%;
+          border: 1px solid $black;
+        }
       }
       .item-price {
-        width: 24%;
+        order: 2;
+        width: 30%;
+        font-size: 90%;
       }
     }
     .item-description {
@@ -45,13 +54,18 @@
     }
     .item-card-button {
       text-align: center;
-      button {
+      margin: 0 auto;
+      form input[type=submit] {
+        padding: 10px 0;
         margin-bottom: 10px;
         width: 95%;
-        background: $lightbrown;
-        color: $black;
         border: 1px transparent;
         border-radius: 5px;
+        background: $lightbrown;
+        color: $black;
+      }
+      form input[type=submit]:hover {
+        background: $gray;
       }
     }
   }
@@ -60,7 +74,7 @@
       font-size: 50px;
     }
     .items-container {
-      margin-top: 20px;
+      margin: 20px auto;
       display: flex;
       justify-content: space-around;
       flex-flow: row wrap;
@@ -68,6 +82,7 @@
         width: 33%;
       }
       .item-card {
+        border: 1px dotted $black;
         width: 30%;
         img {
           max-height: 500px;

--- a/app/assets/stylesheets/categories_items.scss
+++ b/app/assets/stylesheets/categories_items.scss
@@ -16,9 +16,9 @@
     width: 100%;
   }
   .item-card {
+    border-radius: 5px;
     margin: 10px auto;
     padding: 10px;
-    border-radius: 5px;
     .item-card-image {
       text-align: center;
       img {
@@ -26,11 +26,11 @@
       }
     }
     .item-info {
-      margin: 10px;
+      align-items: center;
       display: inline-flex;
       flex-flow: row nowrap;
       justify-content: space-between;
-      align-items: center;
+      margin: 10px;
       .item-title {
         order: 1;
         width: 33%;
@@ -39,30 +39,30 @@
         order: 3;
         width: 10%;
         input {
-          width: 100%;
           border: 1px solid $black;
+          width: 100%;
         }
       }
       .item-price {
+        font-size: 90%;
         order: 2;
         width: 30%;
-        font-size: 90%;
       }
     }
     .item-description {
       margin: 10px;
     }
     .item-card-button {
-      text-align: center;
       margin: 0 auto;
+      text-align: center;
       form input[type=submit] {
-        padding: 10px 0;
-        margin-bottom: 10px;
-        width: 95%;
+        background: $lightbrown;
         border: 1px transparent;
         border-radius: 5px;
-        background: $lightbrown;
         color: $black;
+        margin-bottom: 10px;
+        padding: 10px 0;
+        width: 95%;
       }
       form input[type=submit]:hover {
         background: $gray;
@@ -74,10 +74,10 @@
       font-size: 50px;
     }
     .items-container {
-      margin: 20px auto;
       display: flex;
-      justify-content: space-around;
       flex-flow: row wrap;
+      justify-content: space-around;
+      margin: 20px auto;
       .item-card-button {
         width: 33%;
       }


### PR DESCRIPTION
I propose a few changes to our items styling (for items index and categories show):

1. Implement a flexbox display for the item info row (name, price, quantity). The three items are ordered and auto distributed (space between) based on their size.

2. To get the button color working, I used developer tools to figure out where the button lives in terms of css path, and realized it exists in a form and not a button tag. We had our styles specifying the latter. I also had to specify `input[type=submit]` in order to access the buttons properties. I used all of @akintner 's original styling for the button, just moved it into the right selector.

3. For the desktop view, I added a small dotted border to the cards. I messed around with some colored and transparantish backgrounds, but it seemed off to me. Let me know what you think!

4. You'll also see some margin definitions here and there, just building up some nice whitespace for the eye.

Attached are some screen shots

<img width="1166" alt="screen shot 2017-01-05 at 6 40 14 am" src="https://cloud.githubusercontent.com/assets/19894032/21682542/5f49cbc2-d312-11e6-9f7a-df29fa4d2fc4.png">
<img width="373" alt="screen shot 2017-01-05 at 6 40 23 am" src="https://cloud.githubusercontent.com/assets/19894032/21682543/5f4aedae-d312-11e6-9714-3ffbf730a954.png">
