### PR TITLE
Comment out item quantity number field in items index partial.

### DIFF
--- a/app/views/shared/_items_index.html.haml
+++ b/app/views/shared/_items_index.html.haml
@@ -13,8 +13,8 @@
               = item.name
           %aside.item-price
             #{number_to_currency(item.price_per_unit)} / lb
-          %aside.item-quantity
-            = number_field_tag :quantity
+          -# %aside.item-quantity
+          -#   = number_field_tag :quantity
         %article.item-description
           %p
             = item.description


### PR DESCRIPTION
We may want to use quantities later but right now the functionality is not needed for user stories. Commented out the number field tag in the items index partial.