### PR TITLE
Remove quantity field for items index

### DIFF
--- a/app/assets/stylesheets/categories_items.scss
+++ b/app/assets/stylesheets/categories_items.scss
@@ -50,9 +50,9 @@
         }
       }
       .item-price {
-        text-align: right;
         font-size: 90%;
         order: 2;
+        text-align: right;
         width: 30%;
       }
     }

--- a/app/assets/stylesheets/categories_items.scss
+++ b/app/assets/stylesheets/categories_items.scss
@@ -35,8 +35,8 @@
       justify-content: space-between;
       margin: 10px;
       .item-title {
-          order: 1;
-          width: 33%;
+        order: 1;
+        width: 33%;
         a {
           text-decoration: none;
         }
@@ -50,6 +50,7 @@
         }
       }
       .item-price {
+        text-align: right;
         font-size: 90%;
         order: 2;
         width: 30%;

--- a/app/views/shared/_items_index.html.haml
+++ b/app/views/shared/_items_index.html.haml
@@ -14,9 +14,6 @@
               = link_to item.name, item_path(item)
           %aside.item-price
             = format_price_per_unit(item)
-          %aside.item-quantity
-            = number_field_tag :quantity
-            #{number_to_currency(item.price_per_unit)} / lb
         %article.item-description
           %p
             = item.description


### PR DESCRIPTION
Since none of the stories ask for quantity in the add-to-cart context, I removed that field from the items index partial. It somehow got commented back in, and shows up on the production view.

In sum: remove quantity field, align price text to right. It looks like one of my VS Code extensions also unindented lines 38 and 39 in `categories_items.scss`

@kheppenstall @akintner @wlffann ready for review (ASAP)

Closes #90 