### PR TITLE
404 helper and admin authentication feature test.

### DIFF
--- a/spec/features/admin/admin_dashboard_spec.rb
+++ b/spec/features/admin/admin_dashboard_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature do
-  context 'visit admin dashboard'
+  context 'visit admin dashboard' do
     context 'admin' do
       scenario 'see dashboard' do
         admin = create(:user, role: 1)
@@ -11,24 +11,6 @@ RSpec.feature do
 
         expect(page).to have_content 'Admin Dashboard'
       end
-    end
-
-  context 'user' do
-    scenario '404' do
-      user = create(:user)
-      login_user(user)
-
-      visit admin_dashboard_path
-
-      expect(page).to have_content "The page you were looking for doesn't exist (404)"
-    end
-  end
-
-  context 'visitor' do
-    scenario '404' do
-      visit admin_dashboard_path
-
-      expect(page).to have_content "The page you were looking for doesn't exist (404)"
     end
   end
 end

--- a/spec/features/users/user_does_not_have_admin_privileges_spec.rb
+++ b/spec/features/users/user_does_not_have_admin_privileges_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.feature do 
+  context 'user' do
+    before(:all) do
+      user = create(:user)
+      login_user(user)
+    end
+
+    scenario 'visits admin dashboard' do
+      visit admin_dashboard_path
+
+      expect_404
+    end
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -31,4 +31,8 @@ module FeatureHelpers
     fill_in :password, with: 'password'
     click_on 'Enter'
   end
+
+  def expect_404
+    expect(page).to have_content "The page you were looking for doesn't exist (404)"
+  end
 end


### PR DESCRIPTION
-User cannot visit admin dashboard path
-Add a `expect_404` feature helper method

Closes #13 

Only one person needs to review.