### PR TITLE
Kh dev admin dashboard

### DIFF
--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -21,7 +21,7 @@
     .sort-by {
       width: 50%;
       text-align: left;
-      font-size: 12px;
+      font-size: 14px;
     }
   }
 

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -1,7 +1,7 @@
 .orders-container {
   margin: 20px;
   h3 {
-    font-size: 18px;
+    font-size: 16px;
     padding: 5px 0px;
   }
   p {
@@ -21,6 +21,7 @@
     .sort-by {
       width: 50%;
       text-align: left;
+      font-size: 12px;
     }
   }
 

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -7,6 +7,23 @@
   p {
     font-size: 12px;
   }
+
+  .orders-header {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    margin: 10px auto;
+    width: 100%;
+    align-items: center;
+    .header {
+      width: 50%;
+    }
+    .sort-by {
+      width: 50%;
+      text-align: left;
+    }
+  }
+
   .order {
     display: flex;
     flex-flow: column wrap;

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -8,6 +8,7 @@ class Admin::BaseController < ApplicationController
 
   def dashboard
     @orders = Order.all
+    @statuses = Order.statuses.keys
     render 'admin/dashboard'
   end
 

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -7,8 +7,9 @@ class Admin::BaseController < ApplicationController
   end
 
   def dashboard
-    @orders = Order.all
+    @orders = Order.by_status(params[:status])
     @statuses = Order.statuses.keys
+    @header = params[:status].capitalize if params[:status]
     render 'admin/dashboard'
   end
 

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -7,6 +7,7 @@ class Admin::BaseController < ApplicationController
   end
 
   def dashboard
+    @orders = Order.all
     render 'admin/dashboard'
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :set_head_title
   before_action :require_login
 
-  helper_method :current_user
+  helper_method :current_user, :current_admin?
 
   def set_cart
     @cart = Cart.new(session[:cart])

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -32,11 +32,7 @@ class Order < ApplicationRecord
   end
 
   def self.by_status(status)
-    if Order.statuses.keys.include?(status)
-      Order.send(status)
-    else
-      Order.all
-    end
+    Order.send(status) rescue Order.all
   end
 
   def verified_user?(current_user)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -31,4 +31,11 @@ class Order < ApplicationRecord
     end
   end
 
+  def self.by_status(status)
+    if Order.statuses.keys.include?(status)
+      Order.send(status)
+    else
+      Order.all
+    end
+  end
 end

--- a/app/views/admin/_admin-orders.html.haml
+++ b/app/views/admin/_admin-orders.html.haml
@@ -1,0 +1,26 @@
+.orders-container
+  .orders-header
+    .header
+      %h3 #{@header if @header} Orders
+    .sort-by
+      .dropdown
+        %a.dropdown-toggle{ "data-toggle" => "dropdown", href: "#" }
+          Filter by Status
+          %b.caret
+        %ul.dropdown-menu
+          %li
+            = link_to 'all', admin_dashboard_path
+          - @statuses.each do |status|
+            %li
+              = link_to status, admin_dashboard_path(:status => status)
+  - @orders.each do |order|
+    .order
+      .order-info
+        %p <strong>User: </strong> #{order.user.name}
+        %p <strong>Total:</strong> #{number_to_currency(order.total_price)} 
+        %p <strong>Submitted:</strong> #{order.created_at}
+        %p <strong>Status:</strong> #{order.status}
+        %p <strong>Updated At:</strong> #{order.updated_at}
+        %p <strong>Order ID:</strong> #{order.id}
+      .order-button
+        = link_to 'Order Details', order_path(order), class: 'btn'

--- a/app/views/admin/dashboard.html.haml
+++ b/app/views/admin/dashboard.html.haml
@@ -10,7 +10,22 @@
 %hr
 
 .orders-container
-  %h3 Orders
+  .orders-header
+    .header
+      %h3 Orders
+    .sort-by
+      .dropdown
+        %a.dropdown-toggle{ "data-toggle" => "dropdown", href: "#" }
+          Display by Status
+          %b.caret
+        %ul.dropdown-menu
+          %li
+            = link_to 'all', admin_dashboard_path
+          - @statuses.each do |status|
+            %li
+              = link_to status, admin_dashboard_path
+
+
   - @orders.each do |order|
     .order
       .order-info

--- a/app/views/admin/dashboard.html.haml
+++ b/app/views/admin/dashboard.html.haml
@@ -9,31 +9,4 @@
 
 %hr
 
-.orders-container
-  .orders-header
-    .header
-      %h3 #{@header if @header} Orders
-    .sort-by
-      .dropdown
-        %a.dropdown-toggle{ "data-toggle" => "dropdown", href: "#" }
-          Filter by Status
-          %b.caret
-        %ul.dropdown-menu
-          %li
-            = link_to 'all', admin_dashboard_path
-          - @statuses.each do |status|
-            %li
-              = link_to status, admin_dashboard_path(:status => status)
-
-
-  - @orders.each do |order|
-    .order
-      .order-info
-        %p <strong>User: </strong> #{order.user.name}
-        %p <strong>Total:</strong> #{number_to_currency(order.total_price)} 
-        %p <strong>Submitted:</strong> #{order.created_at}
-        %p <strong>Status:</strong> #{order.status}
-        %p <strong>Updated At:</strong> #{order.updated_at}
-        %p <strong>Order ID:</strong> #{order.id}
-      .order-button
-        = link_to 'Order Details', order_path(order), class: 'btn'
+= render partial: 'admin/admin-orders'

--- a/app/views/admin/dashboard.html.haml
+++ b/app/views/admin/dashboard.html.haml
@@ -12,18 +12,18 @@
 .orders-container
   .orders-header
     .header
-      %h3 Orders
+      %h3 #{@header if @header} Orders
     .sort-by
       .dropdown
         %a.dropdown-toggle{ "data-toggle" => "dropdown", href: "#" }
-          Display by Status
+          Filter by Status
           %b.caret
         %ul.dropdown-menu
           %li
             = link_to 'all', admin_dashboard_path
           - @statuses.each do |status|
             %li
-              = link_to status, admin_dashboard_path
+              = link_to status, admin_dashboard_path(:status => status)
 
 
   - @orders.each do |order|

--- a/app/views/admin/dashboard.html.haml
+++ b/app/views/admin/dashboard.html.haml
@@ -8,3 +8,17 @@
       %strong= "Email: #{current_user.email}"
 
 %hr
+
+.orders-container
+  %h3 Orders
+  - @orders.each do |order|
+    .order
+      .order-info
+        %p <strong>User: </strong> #{order.user.name}
+        %p <strong>Total:</strong> #{number_to_currency(order.total_price)} 
+        %p <strong>Submitted:</strong> #{order.created_at}
+        %p <strong>Status:</strong> #{order.status}
+        %p <strong>Updated At:</strong> #{order.updated_at}
+        %p <strong>Order ID:</strong> #{order.id}
+      .order-button
+        = link_to 'Order Details', order_path(order), class: 'btn'

--- a/spec/features/admin/admin_views_orders_spec.rb
+++ b/spec/features/admin/admin_views_orders_spec.rb
@@ -23,30 +23,13 @@ RSpec.feature do
       end
 
       scenario 'filter orders by status' do
-        click_on 'ordered'
-
-        expect(current_path).to eq admin_dashboard_path
-        expect(page).to have_content 'Ordered Orders'
-        expect_only_orders('ordered?')
-
-        click_on 'paid'
-
-        expect(current_path).to eq admin_dashboard_path
-        expect(page).to have_content 'Paid Orders'
-        expect_only_orders('paid?')
-
-        click_on 'cancelled'
-
-        expect(current_path).to eq admin_dashboard_path
-        expect(page).to have_content 'Cancelled Orders'
-        expect_only_orders('cancelled?')
-
-        click_on 'completed'
-
-        expect(current_path).to eq admin_dashboard_path
-        expect(page).to have_content 'Completed Orders'
-        expect_only_orders('completed?')
-
+        Order.statuses.keys.each do |status|
+          click_on status
+          expect(current_path).to eq admin_dashboard_path
+          expect(page).to have_content "#{status.capitalize} Orders"
+          expect_only_orders("#{status}?")
+        end
+      
         click_on 'all'
 
         expect(current_path).to eq admin_dashboard_path
@@ -55,24 +38,6 @@ RSpec.feature do
           expect(page).to have_content order.id
         end
       end
-
-      scenario ' transitions between statuses' do
-
-      end
     end
   end
 end
-
-# issueEighteen:
-#    title: Admin Orders
-#    body: >
-#      As an Admin
-#      When I visit the dashboard
-#      Then I can see a listing of all orders
-#      And I can see the total number of orders for each status **("Ordered", "Paid", "Cancelled", "Completed")**
-#      And I can see a link for each individual order
-#      And I can filter orders to display by each status type  **("Ordered", "Paid", "Cancelled", "Completed")**
-#      And I have links to transition between statuses
-#        - I can click on "cancel" on individual orders which are "paid" or "ordered"
-#        - I can click on "mark as paid" on orders that are "ordered"
-#        - I can click on "mark as completed" on orders that are "paid"

--- a/spec/features/admin/admin_views_orders_spec.rb
+++ b/spec/features/admin/admin_views_orders_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature do
+  before do
+    @orders = create_list(:order_with_items, 3)
+    user = create(:user, role: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit admin_dashboard_path
+  end
+  context 'visit admin dashboard' do
+    context 'admin' do
+      scenario 'see all orders with links' do
+
+        @orders.each do |order|
+          expect(page).to have_content order.id
+          expect(page).to have_content order.user.name
+          expect(page).to have_link 'Order Details', href: order_path(order)
+        end
+      end
+
+      scenario 'filter orders by status' do
+
+      end
+
+      scenario ' transitions between statuses' do
+
+      end
+    end
+  end
+end
+
+# issueEighteen:
+#    title: Admin Orders
+#    body: >
+#      As an Admin
+#      When I visit the dashboard
+#      Then I can see a listing of all orders
+#      And I can see the total number of orders for each status **("Ordered", "Paid", "Cancelled", "Completed")**
+#      And I can see a link for each individual order
+#      And I can filter orders to display by each status type  **("Ordered", "Paid", "Cancelled", "Completed")**
+#      And I have links to transition between statuses
+#        - I can click on "cancel" on individual orders which are "paid" or "ordered"
+#        - I can click on "mark as paid" on orders that are "ordered"
+#        - I can click on "mark as completed" on orders that are "paid"

--- a/spec/features/admin/admin_views_orders_spec.rb
+++ b/spec/features/admin/admin_views_orders_spec.rb
@@ -2,7 +2,11 @@ require 'rails_helper'
 
 RSpec.feature do
   before do
-    @orders = create_list(:order_with_items, 3)
+    @ordered_orders = create_list(:order_with_items, 2, status: 0)
+    @paid_orders = create_list(:order_with_items, 2, status: 1)
+    @cancelled_orders = create_list(:order_with_items, 2, status: 2)
+    @completed_orders = create_list(:order_with_items, 2, status: 3)
+    @orders = Order.all
     user = create(:user, role: 1)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit admin_dashboard_path
@@ -19,7 +23,57 @@ RSpec.feature do
       end
 
       scenario 'filter orders by status' do
+        click_on 'ordered'
 
+        expect(current_path).to eq admin_dashboard_path
+        
+        @orders.each do |order|
+          if order.ordered?
+            expect(page).to have_content order.id
+          else
+            expect(page).to_not have_content order.id
+          end
+        end
+
+        click_on 'paid'
+
+        expect(current_path).to eq admin_dashboard_path
+        @orders.each do |order|
+          if order.paid?
+            expect(page).to have_content order.id
+          else
+            expect(page).to_not have_content order.id
+          end
+        end
+
+        click_on 'cancelled'
+
+        expect(current_path).to eq admin_dashboard_path
+        @orders.each do |order|
+          if order.cancelled?
+            expect(page).to have_content order.id
+          else
+            expect(page).to_not have_content order.id
+          end
+        end
+
+        click_on 'completed'
+
+        expect(current_path).to eq admin_dashboard_path
+        @orders.each do |order|
+          if order.completed?
+            expect(page).to have_content order.id
+          else
+            expect(page).to_not have_content order.id
+          end
+        end
+
+        click_on 'all'
+
+        expect(current_path).to eq admin_dashboard_path
+        @orders.each do |order|
+          expect(page).to have_content order.id
+        end
       end
 
       scenario ' transitions between statuses' do

--- a/spec/features/admin/admin_views_orders_spec.rb
+++ b/spec/features/admin/admin_views_orders_spec.rb
@@ -26,51 +26,31 @@ RSpec.feature do
         click_on 'ordered'
 
         expect(current_path).to eq admin_dashboard_path
-        
-        @orders.each do |order|
-          if order.ordered?
-            expect(page).to have_content order.id
-          else
-            expect(page).to_not have_content order.id
-          end
-        end
+        expect(page).to have_content 'Ordered Orders'
+        expect_only_orders('ordered?')
 
         click_on 'paid'
 
         expect(current_path).to eq admin_dashboard_path
-        @orders.each do |order|
-          if order.paid?
-            expect(page).to have_content order.id
-          else
-            expect(page).to_not have_content order.id
-          end
-        end
+        expect(page).to have_content 'Paid Orders'
+        expect_only_orders('paid?')
 
         click_on 'cancelled'
 
         expect(current_path).to eq admin_dashboard_path
-        @orders.each do |order|
-          if order.cancelled?
-            expect(page).to have_content order.id
-          else
-            expect(page).to_not have_content order.id
-          end
-        end
+        expect(page).to have_content 'Cancelled Orders'
+        expect_only_orders('cancelled?')
 
         click_on 'completed'
 
         expect(current_path).to eq admin_dashboard_path
-        @orders.each do |order|
-          if order.completed?
-            expect(page).to have_content order.id
-          else
-            expect(page).to_not have_content order.id
-          end
-        end
+        expect(page).to have_content 'Completed Orders'
+        expect_only_orders('completed?')
 
         click_on 'all'
 
         expect(current_path).to eq admin_dashboard_path
+        expect(page).to have_content 'Orders'
         @orders.each do |order|
           expect(page).to have_content order.id
         end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -67,4 +67,14 @@ module FeatureHelpers
   def total(item1, item2, quantity = 1)
     (item1.price_per_unit * quantity + item2.price_per_unit).round(2)
   end
+
+  def expect_only_orders(status)
+    @orders.each do |order|
+      if order.send(status)
+        expect(page).to have_content order.id
+      else
+        expect(page).to_not have_content order.id
+      end
+    end
+  end
 end


### PR DESCRIPTION
-Add feature that admin can view all orders
-Add feature that admin can filter order by status
-Extract orders part of admin dashboard into partial

NOTE: Does not close card 113 or story 18. Still need to add functionality for an admin to edit the status of an order.