### PR TITLE
Refactor most popular method in ItemAnalytics

### DIFF
--- a/app/models/item_analytics.rb
+++ b/app/models/item_analytics.rb
@@ -2,7 +2,7 @@ module ItemAnalytics
 
   def self.most_popular
     item_quantities = Item.joins(:orders_items).group(:item_id).sum(:quantity)
-    max_quantity = item_quantities.values.max 
+    max_quantity = item_quantities.values.max
     Item.find(item_quantities.key(max_quantity))
   end
 

--- a/app/models/item_analytics.rb
+++ b/app/models/item_analytics.rb
@@ -1,7 +1,9 @@
 module ItemAnalytics
 
   def self.most_popular
-    Item.find(Item.joins(:orders_items).group(:item_id).sum(:quantity).max_by{|k,v| v}.first)
+    item_quantities = Item.joins(:orders_items).group(:item_id).sum(:quantity)
+    max_quantity = item_quantities.values.max 
+    Item.find(item_quantities.key(max_quantity))
   end
 
 end

--- a/app/views/shared/_items_index.html.haml
+++ b/app/views/shared/_items_index.html.haml
@@ -8,7 +8,7 @@
 - if active_search?
   %article.category-header
     %h2
-      = Results for \"#{@q.conditions.first.values.first.value}\"
+      = "Results for \"#{@q.conditions.first.values.first.value}\""
   %article.items-container
     - if @items.any?
       = render partial: 'shared/items', locals: { items: @items }


### PR DESCRIPTION
Refactor `#most_popular` in `ItemAnalytics` to three lines as so:

```ruby

def self.most_popular
    item_quantities = Item.joins(:orders_items).group(:item_id).sum(:quantity)
    max_quantity = item_quantities.values.max 
    Item.find(item_quantities.key(max_quantity))
end

```

@akintner @tmikeschu Needs 1 review.